### PR TITLE
Fix incorrect key on traveled path

### DIFF
--- a/lib/props_template/base.rb
+++ b/lib/props_template/base.rb
@@ -22,6 +22,7 @@ module Props
     end
 
     def handle_set_block(key, options)
+      key = format_key(key)
       @stream.push_key(key)
       set_block_content!(options) do
         yield
@@ -33,8 +34,6 @@ module Props
     end
 
     def set!(key, value = nil)
-      key = format_key(key)
-
       if @scope == :array
         raise InvalidScopeForObjError.new('Attempted to set! on an array! scope')
       end
@@ -49,6 +48,7 @@ module Props
           yield
         end
       else
+        key = format_key(key)
         @stream.push_value(value, key)
       end
 

--- a/spec/extensions/traveled_path_spec.rb
+++ b/spec/extensions/traveled_path_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'Props::Template' do
     @controller.request.path = '/some_url'
   end
 
-  it 'finds the correct node and merges it to the top' do
+  it 'returns the path of the node its called from' do
     json = render(<<~PROPS)
       json.data do
         json.comment do
-          json.details do
+          json.full_details do
             json.foo json.traveled_path!
           end
         end
@@ -20,8 +20,8 @@ RSpec.describe 'Props::Template' do
     expect(json).to eql_json({
       data: {
         comment: {
-          details: {
-            foo: 'data.comment.details'
+          fullDetails: {
+            foo: 'data.comment.full_details'
           }
         }
       },


### PR DESCRIPTION
When calling `set!` or `handle_set_block!`, the formatted key gets passed to `base_with_extensions` instead of the raw key. This commits allows the override method to receive the raw key and `super` to format it.

https://github.com/thoughtbot/props_template/issues/5