### PR TITLE
Fix nil templates

### DIFF
--- a/lib/props_template/extensions/partial_renderer.rb
+++ b/lib/props_template/extensions/partial_renderer.rb
@@ -81,7 +81,6 @@ module Props
       partial, pass_opts = [*options[:partial]]
       pass_opts ||= {}
       pass_opts[:locals] ||= {}
-      pass_opts[:locals][:json] = @builder
       pass_opts[:partial] = partial
       pass_opts[:formats] = [:json]
       pass_opts.delete(:handlers)

--- a/lib/props_template/handler.rb
+++ b/lib/props_template/handler.rb
@@ -8,8 +8,8 @@ module Props
     def self.call(template, source = nil)
       source ||= template.source
       # this juggling is required to keep line numbers right in the error
-      %{__already_defined = defined?(json); json||=Props::Template.new(self); #{source};
-        json.result! unless (__already_defined && __already_defined != "method")
+      %{ __finalize = !defined?(@__json); @__json ||= Props::Template.new(self); json = @__json; #{source};
+        json.result! if __finalize
       }
     end
   end

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -21,4 +21,16 @@ RSpec.describe "Props::Template" do
 
     expect(json.strip).to eql('{"data":{"success":"ok"}}')
   end
+
+  context "when no layout exists" do
+    it "skips the layout" do
+      view_path = File.join(File.dirname(__FILE__), "./fixtures")
+      controller = TestController.new
+      controller.prepend_view_path(view_path)
+
+      json = controller.render_to_string("200")
+
+      expect(json.strip).to eql('{"success":"ok"}')
+    end
+  end
 end


### PR DESCRIPTION
Fix nil templates

There's a bug that errors out when a layout isn't available.

In the normal Rails rendering process, `nil` layouts are an acceptable value
and will render a template without a layout when that happens.

In form_props, we depend on
1. a layout yielding back a `json` object so that the template can continue to
render. With no layout, this suddenly errors out.
2. every template except for the layout to have a `json` local passed. We do this
by patching the `render` method on Rails, but this wasn't a great idea since it
does a double lookup and bled into non-json templates. It mayyy also conflict with
jbuilder which also does a `defined?` testing on `json`

To fix this, we change the rendering strategy. We still render top down, but instead
of testing for `defined?(json)` we use a instance variable called `@_props` in the
anonymous view and set a `json` local var to it. This has the immediate benefit of
no longer needing double template lookups, a less intrusive patch, and no longer
needing to assign locals which pollutes the dynamic method naming convention of template.

This resolves #1
