### PR TITLE
Use a method instead of local_assigns

### DIFF
--- a/lib/props_template/layout_patch.rb
+++ b/lib/props_template/layout_patch.rb
@@ -10,6 +10,12 @@ module Props
     end
 
     def render_props_template(view, template, path, locals)
+      view.instance_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def virtual_path_of_template;"#{template.virtual_path}";end
+      RUBY
+
+      # Deprecated: Usage of virtual_path_of_template in local_assigns will
+      # be removed for a method definition above
       layout_locals = locals.dup
       layout_locals[:virtual_path_of_template] = template.virtual_path
 

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -1,5 +1,5 @@
-require_relative "./support/helper"
-require_relative "./support/rails_helper"
+require_relative "support/helper"
+require_relative "support/rails_helper"
 require "props_template/layout_patch"
 require "action_controller"
 

--- a/spec/props_template_spec.rb
+++ b/spec/props_template_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./support/helper"
+require_relative "support/helper"
 
 RSpec.describe "Props::Base" do
   it "initializes" do

--- a/spec/searcher_spec.rb
+++ b/spec/searcher_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./support/helper"
+require_relative "support/helper"
 
 class Collection
   def initialize(ary, rspec)


### PR DESCRIPTION
`virtual_path_of_template` was originally assigned to a local in hopes that the layout would pick it up, but I didn't realize that the layout lookups passed an empty `[]` as a locals so the template never picked it up. That's why I used `local_assigns` which seemed like a hack.

Instead, we're going to def helper method on the anonymous view that's generated with each request.