### PR TITLE
Remove auto camelize lower

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # News
 
+
+* PropsTemplate will no longer automatically `camelize(:lower)` on keys.
+Instead, be explicit about the keys we're serializing.
+
+For example: `json.currentUser` instead of `json.current_user`. This
+is backward breaking. To retain the current behavior, you can do this:
+
+```
+module PropsTemplateOverride
+  def format_key(key)
+    @key_cache ||= {}
+    @key_cache[key] ||= key.camelize(:lower)
+    @key_cache[key]
+  end
+
+  def result!
+    result = super
+    @key_cache = {}
+    result
+  end
+
+  ::Props::BaseWithExtensions.prepend self
+end
+```
+
 ## 0.24.0 (Nov 4th, 2023)
   * Turn the local assigns `virtual_path_of_template` that didn't work into a method on the view
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ json.flash flash.to_h
 json.menu do
   # By default, all keys will be formatted as camelCase. See #change_key_format
 
-  json.current_user do
+  json.currentUser do
     json.email current_user.email
     json.avatar current_user.avatar
     json.inbox current_user.messages.count
@@ -40,7 +40,7 @@ end
 
 json.dashboard(defer: :auto) do
   sleep 5
-  json.complex_post_metric 500
+  json.complexPostMetric 500
 end
 
 json.posts do
@@ -51,13 +51,13 @@ json.posts do
     json.array! paged_posts, key: :id do |post|
       json.id post.id
       json.description post.description
-      json.comments_count post.comments.count
-      json.edit_path edit_post_path(post)
+      json.commentsCount post.comments.count
+      json.editPath edit_post_path(post)
     end
   end
 
-  json.pagination_path posts_path
-  json.current paged_posts.current_page
+  json.paginationPath posts_path
+  json.current pagedPosts.current_page
   json.total @posts.count
 end
 
@@ -98,14 +98,14 @@ Defines the attribute or structure. All keys are automatically camelized lower
 by default. See [Change Key Format](#change-key-format) to change this behavior.
 
 ```ruby
-json.set! :author_details, {...options} do
-  json.set! :first_name, 'David'
+json.set! :authorDetails, {...options} do
+  json.set! :firstName, 'David'
 end
 
 or
 
-json.author_details, {...options} do
-  json.first_name 'David'
+json.authorDetails, {...options} do
+  json.firstName 'David'
 end
 
 
@@ -121,11 +121,11 @@ The inline form defines key and value
 
 ```ruby
 
-json.set! :first_name, 'David'
+json.set! :firstName, 'David'
 
 or
 
-json.first_name 'David'
+json.firstName 'David'
 
 # => { "firstName": "David" }
 ```
@@ -165,7 +165,7 @@ collection = [ {name: 'john'}, {name: 'jim'} ]
 
 json.details do
   json.array! collection, {...options} do |person|
-    json.first_name person[:name]
+    json.firstName person[:name]
   end
 end
 
@@ -348,7 +348,7 @@ Usage:
 
 ```ruby
 json.author(cache: "some_cache_key") do
-  json.first_name "tommy"
+  json.firstName "tommy"
 end
 
 #or
@@ -404,7 +404,7 @@ Usage:
 ```ruby
 json.dashboard(defer: :manual) do
   sleep 10
-  json.some_fancy_metric 42
+  json.someFancyMetric 42
 end
 
 
@@ -412,7 +412,7 @@ end
 
 json.dashboard(defer: [:manual, placeholder: {}]) do
   sleep 10
-  json.some_fancy_metric 42
+  json.someFancyMetric 42
 end
 ```
 
@@ -423,7 +423,7 @@ A auto option is available:
 ```ruby
 json.dashboard(defer: :auto) do
   sleep 10
-  json.some_fancy_metric 42
+  json.someFancyMetric 42
 end
 ```
 
@@ -490,7 +490,7 @@ json.data(search: traversal_path) do
 
     json.personal do
       json.name 'james'
-      json.zip_code 91210
+      json.zipCode 91210
     end
   end
 end
@@ -586,8 +586,8 @@ json.flash flash.to_h
 will render Layout first, then the template when `yield json` is used.
 
 ## Change key format
-By default, all keys will be formatted with `camelized(:lower)`. If you want to
-change this behavior, override it in an initializer:
+By default, keys are not formatted. If you want to change this behavior,
+override it in an initializer:
 
 ```ruby
 Props::BaseWithExtensions.class_eval do

--- a/lib/props_template/base.rb
+++ b/lib/props_template/base.rb
@@ -115,7 +115,6 @@ module Props
       @stream.reset
 
       @scope = nil
-      @key_cache = {}
       json
     end
   end

--- a/lib/props_template/base_with_extensions.rb
+++ b/lib/props_template/base_with_extensions.rb
@@ -5,10 +5,8 @@ module Props
     def initialize(builder, context = nil, options = {})
       @context = context
       @builder = builder
-      # todo: refactor so deferred can be its own class
       @em = ExtensionManager.new(self)
       @traveled_path = []
-      @key_cache = {}
       super()
     end
 
@@ -45,8 +43,7 @@ module Props
     end
 
     def format_key(key)
-      @key_cache[key] ||= key.to_s.camelize(:lower)
-      @key_cache[key].dup
+      key.to_s
     end
 
     def set!(key, options = {}, &block)

--- a/spec/extensions/prop_template_search_spec.rb
+++ b/spec/extensions/prop_template_search_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe("searching the template") do
       json.outer(search: ['outer']) do
         json.inner(search: ['inner', 'foo']) do
           json.foo do
-            json.first_name 'john'
+            json.firstName 'john'
           end
         end
       end
@@ -178,7 +178,7 @@ RSpec.describe("searching the template") do
       json.outer(search: ['outer', 'inner', 'foo']) do
         json.inner(search: ['does_not_exist']) do
           json.foo do
-            json.first_name 'john'
+            json.firstName 'john'
           end
         end
       end

--- a/spec/extensions/rails_cache_spec.rb
+++ b/spec/extensions/rails_cache_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "Props::Template caching" do
   it "caches an object" do
     json = render(<<~PROPS)
       json.author(cache: 'some_cache_key') do
-        json.first_name 'hit'
+        json.firstName 'hit'
       end
 
       json.author2(cache: 'some_cache_key') do
-        json.first_name 'miss'
+        json.firstName 'miss'
       end
     PROPS
 
@@ -40,7 +40,7 @@ RSpec.describe "Props::Template caching" do
       }
 
       json.author(opts) do
-        json.first_name 'hit'
+        json.firstName 'hit'
       end
     PROPS
 
@@ -52,7 +52,7 @@ RSpec.describe "Props::Template caching" do
       }
 
       json.author(opts) do
-        json.first_name 'miss'
+        json.firstName 'miss'
       end
     PROPS
 
@@ -70,7 +70,7 @@ RSpec.describe "Props::Template caching" do
       }
 
       json.author(opts) do
-        json.first_name 'miss'
+        json.firstName 'miss'
       end
     PROPS
 
@@ -207,17 +207,17 @@ RSpec.describe "Props::Template caching" do
   it "has no effect when search is active" do
     json = render(<<~PROPS)
       json.foo(cache:'some_key') do
-        json.first_name 'dave'
+        json.firstName 'dave'
       end
 
       json.bar(cache:'some_key') do
-        json.first_name 'miss'
+        json.firstName 'miss'
       end
 
       json.author(search: ['author', 'details', 'name']) do
         json.details(cache: 'some_key') do
           json.name do
-            json.first_name 'john'
+            json.firstName 'john'
           end
         end
       end
@@ -239,16 +239,16 @@ RSpec.describe "Props::Template caching" do
   it "is reenabled at the found subtree" do
     json = render(<<~PROPS)
       json.foo(cache:'some_key') do
-        json.first_name 'dave'
+        json.firstName 'dave'
       end
 
       json.bar(cache:'some_key') do
-        json.first_name 'miss'
+        json.firstName 'miss'
       end
 
       json.author(search: ['author']) do
         json.details(cache: 'some_key') do
-          json.first_name 'john'
+          json.firstName 'john'
         end
       end
     PROPS

--- a/spec/extensions/traveled_path_spec.rb
+++ b/spec/extensions/traveled_path_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Props::Template" do
     json = render(<<~PROPS)
       json.data do
         json.comment do
-          json.full_details do
+          json.fullDetails do
             json.foo json.traveled_path!
           end
         end
@@ -21,7 +21,7 @@ RSpec.describe "Props::Template" do
       data: {
         comment: {
           fullDetails: {
-            foo: "data.comment.full_details"
+            foo: "data.comment.fullDetails"
           }
         }
       }

--- a/spec/fixtures/_customer.json.props
+++ b/spec/fixtures/_customer.json.props
@@ -1,1 +1,1 @@
-json.first_name customer[:name]
+json.firstName customer[:name]


### PR DESCRIPTION
This commit removes camelize lower on all keys. We had to remove this because superglue deferrals were breaking on multiword keys like `your_trips`. This means we have to be explicit about keys when working with templates.

Disregarding the bug, this is a good move as most people working with superglue for the first time get confused about why the keys don't line up with what they receive on the page component.

This also gives a nice speedup to props_template as we no longer have to deal with camelize. Its now clearly the fastest json builder on rolftimmermans benchmark.

However, this is a backward breaking change. You must manually go through each key and rename it to its `camelCase` equivalent. To restore the original behavior, use something like the following:

```ruby
module PropsTemplateOverride
  def format_key(key)
    @key_cache ||= {}
    @key_cache[key] ||= key.camelize(:lower)
    @key_cache[key]
  end

  def result!
    result = super
    @key_cache = {}
    result
  end

  ::Props::BaseWithExtensions.prepend self
end
```