### PR TITLE
Remove virtual_path_of_template.

### DIFF
--- a/lib/props_template/layout_patch.rb
+++ b/lib/props_template/layout_patch.rb
@@ -10,18 +10,9 @@ module Props
     end
 
     def render_props_template(view, template, path, locals)
-      view.instance_eval <<~RUBY, __FILE__, __LINE__ + 1
-        def virtual_path_of_template;"#{template.virtual_path}";end
-      RUBY
-
-      # Deprecated: Usage of virtual_path_of_template in local_assigns will
-      # be removed for a method definition above
-      layout_locals = locals.dup
-      layout_locals[:virtual_path_of_template] = template.virtual_path
-
-      layout = resolve_layout(path, layout_locals.keys, [formats.first])
+      layout = resolve_layout(path, locals.keys, [formats.first])
       body = if layout
-        layout.render(view, layout_locals) do |json|
+        layout.render(view, locals) do |json|
           template.render(view, locals)
         end
       else


### PR DESCRIPTION
This method was originally created to more easily tie a page json with a page component. It was to be used as the componentIdentifier.

A better and more maintainable approach would be to use a combination of `controller_path` and `action` for the `componentIdentifier`. This removes the hacky-ness of dynamically defining a method, while giving flexibility as two controller actions can render the same template while having a different componentIdentifier.