### PR TITLE
WIP: Utilize props mimetype

### DIFF
--- a/lib/props_template/extensions/partial_renderer.rb
+++ b/lib/props_template/extensions/partial_renderer.rb
@@ -81,7 +81,7 @@ module Props
       pass_opts ||= {}
       pass_opts[:locals] ||= {}
       pass_opts[:partial] = partial
-      pass_opts[:formats] = [:json]
+      pass_opts[:formats] = [:props]
       pass_opts.delete(:handlers)
 
       if !(String === partial)

--- a/lib/props_template/handler.rb
+++ b/lib/props_template/handler.rb
@@ -3,7 +3,7 @@ require "active_support"
 module Props
   class Handler
     cattr_accessor :default_format
-    self.default_format = :json
+    self.default_format = :props
 
     def self.call(template, source = nil)
       source ||= template.source

--- a/lib/props_template/railtie.rb
+++ b/lib/props_template/railtie.rb
@@ -5,6 +5,7 @@ module Props
   class Railtie < ::Rails::Railtie
     initializer :props_template do
       ActiveSupport.on_load :action_view do
+        Mime::Type.register "application/vnd.thoughtbot.props+json", :props
         ActionView::Template.register_template_handler :props, Props::Handler
         require "props_template/dependency_tracker"
         require "props_template/layout_patch"


### PR DESCRIPTION
I was playing around with Superglue in a hobby app, which uses the same controller for html views and api calls. So games/show.json would be your json response, and games/show.html would be your html response.

When you install superglue, it assumes that your json response will be the props, so any jbuilder templates will no longer function in favor of the prop templates. This didn't feel right, so I went poking around at adding a new mime type.

This PR allows specifying the format for a request as `:props` rather than `:json`. Your file would have to be names `[name].props` to be picked up properly.

There's a problem with the PR that I can't figure out. When this change is implemented, if you have an `application.props` file in app/views/layouts, it will be rendered instead of your jbuilder file when requesting a json response.