### PR TITLE
Enable template rendering in API only Rails apps

### DIFF
--- a/lib/props_template/railtie.rb
+++ b/lib/props_template/railtie.rb
@@ -10,5 +10,18 @@ module Props
         require "props_template/layout_patch"
       end
     end
+
+    module ::ActionController
+      module ApiRendering
+        include ActionView::Rendering
+      end
+    end
+
+    ActiveSupport.on_load :action_controller do
+      if name == "ActionController::API"
+        include ActionController::Helpers
+        include ActionController::ImplicitRender
+      end
+    end
   end
 end


### PR DESCRIPTION
I tried to migrate from jbuilder to props_template on a Rails app with `config.api_only` set to `true`, and I was surprised that all my specs were failing when my requests returned `204 No Content`.

It turns out, `api_only` disables template rendering, as well as helpers and implicit rendering.

Similar gems such as [jbuilder](https://github.com/rails/jbuilder/blob/387561395daf471f05287fc67d28e0a296988f57/lib/jbuilder/railtie.rb#L12-L25) or [jb](https://github.com/amatsuda/jb/blob/master/lib/jb/railtie.rb#L17-L30) re-enable those in their railtie file. I think props_template could be helpful by doing the same.