### PR TITLE
Fix issue with templates that don't have a virtual_path

### DIFF
--- a/lib/props_template/layout_patch.rb
+++ b/lib/props_template/layout_patch.rb
@@ -1,7 +1,7 @@
 module Props
   module LayoutPatch
     def render_template(view, template, layout_name, locals)
-      unless view.respond_to? :active_template_virtual_path
+      if !view.respond_to?(:active_template_virtual_path) && template.respond_to?(:virtual_path)
         view.instance_eval <<~RUBY, __FILE__, __LINE__ + 1
           def active_template_virtual_path; "#{template.virtual_path}";end
         RUBY

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -33,4 +33,14 @@ RSpec.describe "Props::Template" do
       expect(json.strip).to eql('{"success":"ok"}')
     end
   end
+
+  it "allows rendering of templates that do not have a virtual_path" do
+    view_path = File.join(File.dirname(__FILE__), "./fixtures")
+    controller = TestController.new
+    controller.prepend_view_path(view_path)
+
+    expect(
+      controller.render_to_string(plain: "some text")
+    ).to eql "some text"
+  end
 end


### PR DESCRIPTION
The layout patch needed to account for inline renders like `render(plain: "hello")` or `send_data` that don't have a virtual path.

Without this fix, applications using props_template were throwing:

```
undefined method 'virtual_path' for an instance of ActionView::Template::Text
```