### PR TITLE
Fix Locals need to be shallow cloned.

### DIFF
--- a/lib/props_template/extensions/partial_renderer.rb
+++ b/lib/props_template/extensions/partial_renderer.rb
@@ -137,7 +137,7 @@ module Props
 
       partial, rest = [*options[:partial]]
       rest = (rest || {}).clone
-      locals = rest[:locals] || {}
+      locals = (rest[:locals] || {}).clone
       rest[:locals] = locals
 
       if item

--- a/spec/extensions/partial_render_spec.rb
+++ b/spec/extensions/partial_render_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe "Props::Template" do
     ])
   end
 
-  it "renders an array with :locals" do
+  it "renders an array with default :locals when locals is blank" do
     json = render(<<~PROPS)
       emails = [
         {value: 'joe@j.com'},
@@ -308,8 +308,6 @@ RSpec.describe "Props::Template" do
       json.array! emails, partial: ['simple_as', locals: {}] do
       end
     PROPS
-
-    puts json.inspect
 
     expect(json).to eql_json([
       {foo: "joe@j.com"},


### PR DESCRIPTION
Resolves #20. `prop_template` prebuilds an array of options before handling it off to handle_collection to build. I recall this being somewhat related to faster collection rendering. Unfortunately, the trade off is that we have to be cognizant of how we mutate deeply nested options as those can be the same object. In this case, I missed a required clone on locals.