### PR TITLE
Feature: rendering optional attributes

### DIFF
--- a/lib/props_template.rb
+++ b/lib/props_template.rb
@@ -22,6 +22,7 @@ module Props
     self.template_lookup_options = {handlers: [:props]}
 
     delegate :result!, :array!,
+      :optional!,
       :deferred!,
       :fragments!,
       :set_block_content!,

--- a/lib/props_template/base_with_extensions.rb
+++ b/lib/props_template/base_with_extensions.rb
@@ -7,6 +7,7 @@ module Props
       @builder = builder
       @em = ExtensionManager.new(self)
       @traveled_path = []
+
       super()
     end
 

--- a/lib/props_template/extensions/partial_renderer.rb
+++ b/lib/props_template/extensions/partial_renderer.rb
@@ -140,6 +140,11 @@ module Props
       locals = (rest[:locals] || {}).clone
       rest[:locals] = locals
 
+      if rest
+        @base.contains ||= @base.transform_contain_keys(rest.dig(:locals, :contains))
+        rest[:locals][:contains] = @base.contains
+      end
+
       if item
         as = if !rest[:as]
           retrieve_variable(partial)

--- a/lib/props_template/searcher.rb
+++ b/lib/props_template/searcher.rb
@@ -1,6 +1,9 @@
 module Props
   class Searcher
+    attr_accessor :contains
     attr_reader :builder, :context, :fragments, :traveled_path
+
+    delegate :transform_contain_keys, to: :builder!
 
     def initialize(builder, path = [], context = nil)
       @search_path = path
@@ -10,7 +13,12 @@ module Props
       @found_options = nil
       @builder = builder
       @traveled_path = []
+      @contains = nil
       @partialer = Partialer.new(self, context, builder)
+    end
+
+    def builder!
+      @builder
     end
 
     def deferred!

--- a/spec/extensions/partial_render_spec.rb
+++ b/spec/extensions/partial_render_spec.rb
@@ -323,4 +323,70 @@ RSpec.describe "Props::Template" do
 
     expect(json).to eql_json([])
   end
+
+  context "when locals with contains" do
+    it "renders only required attributes" do
+      json = render(<<~PROPS)
+        emails = [
+          {value: 'joe@j.com'},
+          {value: 'foo@f.com'},
+        ]
+        json.array! emails, partial: ['optional', locals: {contains: [:email]}] do
+        end
+      PROPS
+
+      expect(json).to eql_json([
+        {email: "joe@j.com"},
+        {email: "foo@f.com"}
+      ])
+    end
+
+    it "renders object with all nested attributes" do
+      json = render(<<~PROPS)
+        emails = [
+          {value: 'joe@j.com'},
+          {value: 'foo@f.com'},
+        ]
+        json.array! emails, partial: ['optional', locals: {contains: [emailAsObject: []]}] do
+        end
+      PROPS
+
+      expect(json).to eql_json([
+        {emailAsObject: {email: "joe@j.com", something: nil}},
+        {emailAsObject: {email: "foo@f.com", something: nil}}
+      ])
+    end
+
+    it "renders object with only required nested attributes" do
+      json = render(<<~PROPS)
+        emails = [
+          {value: 'joe@j.com'},
+          {value: 'foo@f.com'},
+        ]
+        json.array! emails, partial: ['optional', locals: {contains: [emailAsObject: [:email]]}] do
+        end
+      PROPS
+
+      expect(json).to eql_json([
+        {emailAsObject: {email: "joe@j.com"}},
+        {emailAsObject: {email: "foo@f.com"}}
+      ])
+    end
+
+    it "renders all attributes" do
+      json = render(<<~PROPS)
+        emails = [
+          {value: 'joe@j.com'},
+          {value: 'foo@f.com'},
+        ]
+        json.array! emails, partial: ['optional', locals: {contains: [:email, {emailAsObject: [:email]}, :something]}] do
+        end
+      PROPS
+
+      expect(json).to eql_json([
+        {email: "joe@j.com", something: nil, emailAsObject: {email: "joe@j.com"}},
+        {email: "foo@f.com", something: nil, emailAsObject: {email: "foo@f.com"}}
+      ])
+    end
+  end
 end

--- a/spec/fixtures/_optional.json.props
+++ b/spec/fixtures/_optional.json.props
@@ -1,0 +1,7 @@
+json.optional! :email, -> { optional[:value] }
+json.optional! :something, -> { nil }
+
+json.optional! :emailAsObject do
+  json.optional! :email, -> { optional[:value] }
+  json.optional! :something, -> { nil }
+end

--- a/spec/props_template_spec.rb
+++ b/spec/props_template_spec.rb
@@ -296,4 +296,52 @@ RSpec.describe "Props::Base" do
       }.to raise_error(Props::InvalidScopeForArrayError)
     end
   end
+
+  context "optional!" do
+    it "sets a value" do
+      json = Props::Base.new
+      json.optional! :foo, -> { "bar" }
+      attrs = json.result!.strip
+
+      expect(attrs).to eql_json({
+        foo: "bar"
+      })
+    end
+
+    it "sets a empty obj when block is empty" do
+      json = Props::Base.new
+      json.optional! :foo do
+      end
+      attrs = json.result!.strip
+
+      expect(attrs).to eql_json({
+        foo: {}
+      })
+    end
+
+    it "sets a empty obj when nested block is empty" do
+      json = Props::Base.new
+      json.optional! :foo do
+        json.optional! :bar do
+        end
+      end
+      attrs = json.result!.strip
+
+      expect(attrs).to eql_json({
+        foo: {
+          bar: {}
+        }
+      })
+    end
+
+    it "sets a null value" do
+      json = Props::Base.new
+      json.optional! :foo, -> { nil }
+      attrs = json.result!.strip
+
+      expect(attrs).to eql_json({
+        foo: nil
+      })
+    end
+  end
 end


### PR DESCRIPTION
@jho406 in continue https://github.com/thoughtbot/props_template/issues/30

`json.optional!` - defines attribute or structure and marks it as optional, during serialization this method checks condition and renders or does not render such attribute

example of usage

```
json.optional! :properties do
  json.optional! :value, -> { object.value } # lambda here is to avoid value calculations before checking conditions for rendering
end
```

Works with partials, I just think how optionals can be used in simple template