### PR TITLE
Add news for version 0.37.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,13 @@
 # News
 
+## 0.37.0 (Dec 31, 2024)
+  * Add a `dig` option for traversing into a template.
+    It's basically an alias of the already existing `search` option.
+  * Drop support for Rails 6.
+
 ## 0.36.0 (Nov 21, 2024)
 
-New features `extract!`, `partial!`, and test improvments.
+New features `extract!`, `partial!`, and test improvements.
 
 ## 0.35.0 (Jul 20, 2024)
 


### PR DESCRIPTION
I was trying to update this library in one of my Rails apps to the latest version (0.37.0), but I noticed that the `NEWS.md` file was not updated. This PR fixes that :)