### PR TITLE
fix meta data not hydrating for first cache

### DIFF
--- a/lib/props_template/extension_manager.rb
+++ b/lib/props_template/extension_manager.rb
@@ -86,12 +86,13 @@ module Props
           result
         end
 
+        meta, raw_json = state.split("\n")
+        next_deferred, next_fragments = Oj.load(meta)
+        deferred.push(*next_deferred)
+        fragments.push(*next_fragments)
+
         if !recently_cached
-          meta, raw_json = state.split("\n")
-          next_deferred, next_fragments = Oj.load(meta)
           base.stream.push_json(raw_json)
-          deferred.push(*next_deferred)
-          fragments.push(*next_fragments)
         end
       else
         yield

--- a/spec/extensions/defer_extension_spec.rb
+++ b/spec/extensions/defer_extension_spec.rb
@@ -474,7 +474,18 @@ RSpec.describe "Props::Template" do
       json.deferred json.deferred!
     PROPS
 
-    render(props)
+    json = render(props)
+
+    expect(json).to eql_json({
+      outer: {
+        inner: {
+          greeting: {}
+        }
+      },
+      deferred: [
+        {url: "/some_url?props_at=outer.inner.greeting", path: "outer.inner.greeting", type: "auto"}
+      ]
+    })
     json = render(props)
 
     expect(json).to eql_json({


### PR DESCRIPTION
This affects caching's first hit when used with Superglue's deferred and fragment. Fragments and deferred would be missing when it should be populated.

This fixes it by moving the meta data hydration to always, and we also add a test for it.