### PR TITLE
Add ability to disable deferments

### DIFF
--- a/lib/props_template.rb
+++ b/lib/props_template.rb
@@ -26,6 +26,7 @@ module Props
       :extract!,
       :deferred!,
       :fragments!,
+      :disable_deferments!,
       :set_block_content!,
       :traveled_path!,
       to: :builder!

--- a/lib/props_template/base_with_extensions.rb
+++ b/lib/props_template/base_with_extensions.rb
@@ -10,6 +10,10 @@ module Props
       super()
     end
 
+    def disable_deferments!
+      @em.disable_deferments
+    end
+
     def deferred!
       @em.deferred
     end

--- a/lib/props_template/extension_manager.rb
+++ b/lib/props_template/extension_manager.rb
@@ -12,9 +12,16 @@ module Props
       @cache = Cache.new(@context)
     end
 
+    def disable_deferments
+      @deferment.disable!
+    end
+
     def refine_options(options, item = nil)
       options = @partialer.refine_options(options, item)
-      options = @deferment.refine_options(options, item)
+      if !@deferment.disabled
+        options = @deferment.refine_options(options, item)
+      end
+
       Cache.refine_options(options, item)
     end
 
@@ -40,7 +47,7 @@ module Props
     def handle(options)
       return yield if !has_extensions(options)
 
-      if options[:defer]
+      if options[:defer] && !@deferment.disabled
         placeholder = @deferment.handle(options)
         base.stream.push_value(placeholder)
         @fragment.handle(options)

--- a/lib/props_template/extensions/deferment.rb
+++ b/lib/props_template/extensions/deferment.rb
@@ -1,10 +1,15 @@
 module Props
   class Deferment
-    attr_reader :deferred
+    attr_reader :deferred, :disabled
 
     def initialize(base, deferred = [])
       @deferred = deferred
       @base = base
+      @disabled = false
+    end
+
+    def disable!
+      @disabled = true
     end
 
     def refine_options(options, item = nil)

--- a/spec/extensions/defer_extension_spec.rb
+++ b/spec/extensions/defer_extension_spec.rb
@@ -30,6 +30,33 @@ RSpec.describe "Props::Template" do
     })
   end
 
+  it "disables deferments" do
+    json = render(<<~PROPS)
+      json.disable_deferments!
+
+      json.outer do
+        json.inner(defer: [:auto, placeholder: {}]) do
+          json.greeting(defer: :auto) do
+            json.foo 'hello world'
+          end
+        end
+      end
+
+      json.deferred json.deferred!
+    PROPS
+
+    expect(json).to eql_json({
+      outer: {
+        inner: {
+          greeting: {
+            foo: "hello world"
+          }
+        }
+      },
+      deferred: []
+    })
+  end
+
   it "defers a block from loading, and replaces with a custom placeholder" do
     json = render(<<~PROPS)
       json.outer do

--- a/spec/extensions/fragments_spec.rb
+++ b/spec/extensions/fragments_spec.rb
@@ -64,6 +64,52 @@ RSpec.describe "Props::Template fragments" do
       ]
     })
   end
+  it "populates fragments even if deferment is disabled" do
+    json = render(<<~PROPS)
+      json.disable_deferments!
+      json.outer do
+        json.inner(partial: ['simple', fragment: :simple], defer: :auto) do
+        end
+      end
+
+      json.fragments json.fragments!
+      json.deferred json.deferred!
+    PROPS
+
+    expect(json).to eql_json({
+      outer: {
+        inner: {foo:"bar"}
+      },
+      fragments: [
+        {type: "simple", partial: "simple", path: "outer.inner"}
+      ],
+      deferred: []
+    })
+  end
+  
+  it "renders deferment and populates fragments" do
+    json = render(<<~PROPS)
+      json.outer do
+        json.inner(partial: ['simple', fragment: :simple], defer: :auto) do
+        end
+      end
+
+      json.fragments json.fragments!
+      json.deferred json.deferred!
+    PROPS
+
+    expect(json).to eql_json({
+      outer: {
+        inner: {}
+      },
+      fragments: [
+        {type: "simple", partial: "simple", path: "outer.inner"}
+      ],
+      deferred: [
+        {url: "?props_at=outer.inner", path: "outer.inner", type: "auto"},
+      ]
+    })
+  end
 
   it "renders an array of partials with fragments" do
     json = render(<<~PROPS)


### PR DESCRIPTION
This creates the option `json.disable_deferments!` that will disable any deferment enabled functionality in the template. Its used for when rendering a template during a `post` (`def create`) request. This makes sense because Deferment works with GET requests at controller actions that don't mutate.