### PR TITLE
Fix issue with partial rendering with no layout

### DIFF
--- a/lib/props_template/partial_patch.rb
+++ b/lib/props_template/partial_patch.rb
@@ -1,0 +1,39 @@
+module Props
+  module PartialPatch
+    def render(partial, context, block)
+      template = find_template(partial, template_keys(partial))
+
+      if !block && (layout = @options[:layout])
+        layout = find_template(layout.to_s, template_keys(partial))
+      end
+
+      if template.respond_to?(:handler) && template.handler == Props::Handler && layout
+        render_partial_props_template(context, @locals, template, layout, block)
+      else
+        super
+      end
+    end
+
+    def render_partial_props_template(view, locals, template, layout, block)
+      ActiveSupport::Notifications.instrument(
+        "render_partial.action_view",
+        identifier: template.identifier,
+        layout: layout && layout.virtual_path,
+        locals: locals
+      ) do |payload|
+        body = if layout
+          layout.render(view, locals, add_to_stack: !block) do |json|
+            template.render(view, locals)
+          end
+        else
+          template.render(view, locals)
+        end
+
+        build_rendered_template(body, template)
+      end
+    end
+  end
+end
+
+ActionView::PartialRenderer.prepend(Props::PartialPatch)
+

--- a/lib/props_template/railtie.rb
+++ b/lib/props_template/railtie.rb
@@ -8,6 +8,7 @@ module Props
         ActionView::Template.register_template_handler :props, Props::Handler
         require "props_template/dependency_tracker"
         require "props_template/layout_patch"
+        require "props_template/partial_patch"
       end
     end
 

--- a/spec/extensions/partial_patch_spec.rb
+++ b/spec/extensions/partial_patch_spec.rb
@@ -1,0 +1,21 @@
+require_relative "../support/helper"
+require_relative "../support/rails_helper"
+require "props_template/partial_patch"
+
+require "action_controller"
+RSpec.describe "Props::Template partial patch" do
+  it "renders with a partial and layout" do
+    result = @controller.render(partial: "comment", layout: "stream_message").chomp
+
+    expect(result).to eql_json({
+      greeting: "Hello world",
+      data: {
+        title: "some title",
+        details: {
+          body: "hello world"
+        },
+      }
+    })
+  end
+end
+

--- a/spec/fixtures/layouts/_stream_message.json.props
+++ b/spec/fixtures/layouts/_stream_message.json.props
@@ -1,0 +1,5 @@
+json.greeting "Hello world"
+
+json.data do
+  yield
+end

--- a/spec/support/rails_helper.rb
+++ b/spec/support/rails_helper.rb
@@ -8,6 +8,7 @@ require "minitest"
 require "action_view"
 require "action_view/testing/resolvers"
 require "action_view/template/resolver"
+require "action_dispatch"
 
 class FakeView < ActionView::Base
   # include Rails.application.routes.url_helpers
@@ -70,5 +71,12 @@ ActionView::Template.register_template_handler :props, Props::Handler
 RSpec.configure do |config|
   config.before(:example) do
     @controller = ActionView::TestCase::TestController.new
+    @controller.request = ActionDispatch::TestRequest.create
+    @controller.response = ActionDispatch::TestResponse.new
+    @controller.instance_variable_set(:@_response, @controller.response)
+    @controller.cache_store = Rails.cache
+    view_path = File.join(File.dirname(__FILE__), "../fixtures")
+    @controller.prepend_view_path(view_path)
+    @controller.formats = [:json]
   end
 end


### PR DESCRIPTION
Rendering a `props` template with a layout was fixed with `layout_patch`, but rendering a `props` partial with a template was not covered. This will be used pretty extensively with v2 of superglue_rails, so this PR fixes that. 