### PR TITLE
Add support for child!

### DIFF
--- a/lib/props_template.rb
+++ b/lib/props_template.rb
@@ -22,6 +22,7 @@ module Props
     self.template_lookup_options = {handlers: [:props]}
 
     delegate :result!, :array!,
+      :child!,
       :partial!,
       :extract!,
       :deferred!,

--- a/lib/props_template/searcher.rb
+++ b/lib/props_template/searcher.rb
@@ -60,42 +60,75 @@ module Props
       nil
     end
 
-    def array!(collection, options = {}, &block)
+    def array!(collection = nil, options = {}, &block)
       return if @found_block
 
-      key_index = @search_path[@depth]
-      id_name, id_val = key_index.to_s.split("=")
-
-      if id_val
-        id_val = id_val.to_i
-        item = collection.member_by(id_name, id_val)
+      if collection.nil?
+        # Handle child! mode - initialize child_index for searching
+        @child_index = nil
+        yield
       else
-        index = id_name.to_i
-        item = collection.member_at(index)
-      end
+        # Original collection handling
+        key_index = @search_path[@depth]
+        id_name, id_val = key_index.to_s.split("=")
 
-      if item
-        pass_opts = @partialer.refine_options(options, item)
+        if id_val
+          id_val = id_val.to_i
+          item = collection.member_by(id_name, id_val)
+        else
+          index = id_name.to_i
+          item = collection.member_at(index)
+        end
+
+        if item
+          pass_opts = @partialer.refine_options(options, item)
+          @traveled_path.push(key_index)
+
+          if @depth == @search_path.size - 1
+            @found_options = pass_opts
+            @found_block = proc {
+              yield item, 0
+            }
+            return
+          end
+
+          @depth += 1
+          if pass_opts[:partial]
+            # todo: what happens when cached: true is passed?
+            # would there be any problems with not using the collection_rende?
+            @partialer.handle(pass_opts)
+          else
+            yield item, 0
+          end
+          @depth -= 1
+        end
+      end
+    end
+
+    def child!(options={}, &block)
+      return if @found_block
+
+      child_index = @child_index || -1
+      child_index += 1
+
+      key_index = @search_path[@depth]
+      target_index = key_index.to_i
+
+      if child_index == target_index
         @traveled_path.push(key_index)
 
         if @depth == @search_path.size - 1
-          @found_options = pass_opts
-          @found_block = proc {
-            yield item, 0
-          }
+          @found_options = {}
+          @found_block = block
           return
         end
 
         @depth += 1
-        if pass_opts[:partial]
-          # todo: what happens when cached: true is passed?
-          # would there be any problems with not using the collection_rende?
-          @partialer.handle(pass_opts)
-        else
-          yield item, 0
-        end
+        yield
         @depth -= 1
       end
+
+      @child_index = child_index    
     end
   end
 end

--- a/spec/child_searcher_spec.rb
+++ b/spec/child_searcher_spec.rb
@@ -1,0 +1,138 @@
+require_relative "support/helper"
+require_relative "support/rails_helper"
+
+RSpec.describe "Props::Template child! with searcher" do
+  before do
+    @controller.request.path = "/some_url"
+  end
+
+  context "dig functionality with child!" do
+    it "finds specific child by index using dig" do
+      json = render(<<~PROPS)
+        json.data(dig: ['data', 'posts', '1', 'comment']) do
+          json.posts do
+            json.array! do
+              json.child! do
+                json.comment do
+                  json.title "wow"
+                end
+              end
+              json.child! do
+                json.comment do
+                  json.title "noway"
+                end
+              end
+            end
+          end
+        end
+      PROPS
+
+      expect(json).to eql_json({
+        data: {
+          title: "noway"
+        }
+      })
+    end
+
+    it "finds first child when index is 0" do
+      json = render(<<~PROPS)
+        json.data(dig: ['data', 'posts', '0', 'comment']) do
+          json.posts do
+            json.array! do
+              json.child! do
+                json.comment do
+                  json.title "first"
+                end
+              end
+              json.child! do
+                json.comment do
+                  json.title "second"
+                end
+              end
+            end
+          end
+        end
+      PROPS
+
+      expect(json).to eql_json({
+        data: {
+          title: "first"
+        }
+      })
+    end
+
+    it "works with deeper nested paths" do
+      json = render(<<~PROPS)
+        json.data(dig: ['data', 'content', '1', 'nested', '0']) do
+          json.content do
+            json.array! do
+              json.child! do
+                json.nested do
+                  json.array! do
+                    json.content do
+                      json.value "skip this"
+                    end
+                  end
+                end
+              end
+              json.child! do
+                json.nested do
+                  json.array! do
+                    json.child! do
+                      json.value "found it"
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      PROPS
+
+      expect(json).to eql_json({
+        data: {value: "found it"}
+      })
+    end
+
+    it "returns nothing when child index doesn't exist" do
+      json = render(<<~PROPS)
+        json.data(dig: ['data', 'posts', '5']) do
+          json.posts do
+            json.array! do
+              json.child! do
+                json.title "only child"
+              end
+            end
+          end
+        end
+      PROPS
+
+      expect(json).to eql_json({})
+    end
+  end
+
+  context "search functionality with child!" do
+    it "finds child using search parameter" do
+      json = render(<<~PROPS)
+        json.data(search: ['data', 'items', '0']) do
+          json.items do
+            json.array! do
+              json.child! do
+                json.name "target item"
+              end
+              json.child! do
+                json.name "other item"
+              end
+            end
+          end
+        end
+      PROPS
+
+      expect(json).to eql_json({
+        data: {
+          name: "target item"
+        }
+      })
+    end
+  end
+end

--- a/spec/child_spec.rb
+++ b/spec/child_spec.rb
@@ -1,0 +1,158 @@
+require_relative "support/helper"
+
+RSpec.describe "Props::Base child!" do
+  context "basic functionality" do
+    it "creates an array with child! blocks" do
+      json = Props::Base.new
+      json.array! do
+        json.child! do
+          json.set! :title, "hello world"
+        end
+      end
+
+      attrs = json.result!.strip
+      expect(attrs).to eql_json([
+        { title: "hello world" }
+      ])
+    end
+
+    it "creates an array with multiple child! blocks" do
+      json = Props::Base.new
+      json.array! do
+        json.child! do
+          json.set! :title, "first"
+        end
+        json.child! do
+          json.set! :title, "second"
+        end
+      end
+
+      attrs = json.result!.strip
+      expect(attrs).to eql_json([
+        { title: "first" },
+        { title: "second" }
+      ])
+    end
+
+    it "creates nested objects within child! blocks" do
+      json = Props::Base.new
+      json.array! do
+        json.child! do
+          json.set! :comment do
+            json.set! :title, "wow"
+          end
+        end
+        json.child! do
+          json.set! :comment do
+            json.set! :title, "noway"
+          end
+        end
+      end
+
+      attrs = json.result!.strip
+      expect(attrs).to eql_json([
+        { comment: { title: "wow" } },
+        { comment: { title: "noway" } }
+      ])
+    end
+  end
+  it "allows the child to be an array" do
+    json = Props::Base.new
+    json.array! do
+      json.child! do
+        json.array! do
+          json.child! do
+          end
+        end
+      end
+    end
+
+    attrs = json.result!.strip
+    expect(attrs).to eql_json([
+     [{}] 
+    ])
+  end
+
+  context "validation" do
+    it "raises error when child! is used outside array! blocks" do
+      json = Props::Base.new
+      
+      expect {
+        json.set! :metrics do
+          json.child! do
+            json.set! :title, "test"
+          end
+        end
+      }.to raise_error(Props::InvalidScopeForChildError, "child! can only be used in a `array!` with no arguments")
+    end
+
+    it "raises error when child! is used with array! that has arguments" do
+      json = Props::Base.new
+      
+      expect {
+        json.array! [1, 2] do |post|
+          json.child! do
+            json.set! :title, "test"
+          end
+        end
+      }.to raise_error(Props::InvalidScopeForChildError, "child! can only be used in a `array!` with no arguments")
+    end
+
+    it "raises error when child! has no block" do
+      json = Props::Base.new
+      
+      expect {
+        json.array! do
+          json.child!
+        end
+      }.to raise_error(ArgumentError, "child! requires a block")
+    end
+  end
+
+  context "mixed with regular set!" do
+    it "allows mixing array! child! with outer set!" do
+      json = Props::Base.new
+      json.set! :data do
+        json.set! :posts do
+          json.array! do
+            json.child! do
+              json.set! :title, "First post"
+            end
+            json.child! do
+              json.set! :title, "Second post"
+            end
+          end
+        end
+      end
+
+      attrs = json.result!.strip
+      expect(attrs).to eql_json({
+        data: {
+          posts: [
+            { title: "First post" },
+            { title: "Second post" }
+          ]
+        }
+      })
+    end
+  end
+
+  context "empty child! blocks" do
+    it "creates empty objects for empty child! blocks" do
+      json = Props::Base.new
+      json.array! do
+        json.child! do
+        end
+        json.child! do
+          json.set! :title, "not empty"
+        end
+      end
+
+      attrs = json.result!.strip
+      expect(attrs).to eql_json([
+        {},
+        { title: "not empty" }
+      ])
+    end
+  end
+end

--- a/spec/extensions/fragments_spec.rb
+++ b/spec/extensions/fragments_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Props::Template fragments" do
         {type: "simple", partial: "simple", path: "outer.inner"}
       ],
       deferred: [
-        {url: "?props_at=outer.inner", path: "outer.inner", type: "auto"},
+        {url: "/?props_at=outer.inner", path: "outer.inner", type: "auto"}
       ]
     })
   end

--- a/spec/props_template_spec.rb
+++ b/spec/props_template_spec.rb
@@ -219,6 +219,36 @@ RSpec.describe "Props::Base" do
       expect(attrs).to eql_json([])
     end
 
+    it "creates an empty array when passed nothing" do
+      json = Props::Base.new
+      json.array! do
+      end
+
+      attrs = json.result!.strip
+
+      expect(attrs).to eql_json([])
+    end
+
+    it "does not allow nesting array! directly in array!" do
+      json = Props::Base.new
+      expect { 
+        json.array! do
+          json.array! do
+          end
+        end
+      }.to raise_error(Props::InvalidScopeForArrayError)
+    end
+
+    it "does not allow set be called when inside of array! with no args" do
+      json = Props::Base.new
+
+      expect{
+        json.array! do
+          json.set! :foo, "first"
+        end
+      }.to raise_error(Props::InvalidScopeForObjError)
+    end
+
     it "creates an array of empty arrays when passed an empty collection" do
       json = Props::Base.new
       json.array! [1] do |num|


### PR DESCRIPTION
This adds support for `child!`. Its slightly different from the jbuidler version. `child!` will only work under arrays with no arguments and a single block.

```
json.array! do
  json.child! do
    json.greet "Hello world"
  end
  json.child! do
    json.title "Something"
  end
end
```

this would output:

```
[
  {greet: "Hello world"},
  {title: "Something"}
]
```