### PR TITLE
Change type to ID

### DIFF
--- a/lib/props_template/extensions/fragment.rb
+++ b/lib/props_template/extensions/fragment.rb
@@ -9,16 +9,16 @@ module Props
 
     def handle(options)
       return if !options[:partial]
-      partial_name, partial_opts = options[:partial]
+      _partial_name, partial_opts = options[:partial]
       fragment = partial_opts[:fragment]
 
       if String === fragment || Symbol === fragment
-        fragment_name = fragment.to_s
+        key = fragment.to_s
         path = @base.traveled_path.join(".")
-        @name = fragment_name
+        @name =key 
 
         @fragments.push(
-          {type: fragment_name, partial: partial_name, path: path}
+          {id: key, path: path}
         )
       end
     end

--- a/spec/extensions/fragments_spec.rb
+++ b/spec/extensions/fragments_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Props::Template fragments" do
         }
       },
       fragments: [
-        {type: :simple, partial: "simple", path: "outer.inner"},
-        {type: :simple, partial: "simple", path: "outer.inner2"}
+        {id: :simple, path: "outer.inner"},
+        {id: :simple, path: "outer.inner2"}
       ]
     })
   end
@@ -60,7 +60,7 @@ RSpec.describe "Props::Template fragments" do
         }
       },
       fragments: [
-        {type: :simple, partial: "simple", path: "outer.inner.simple"}
+        {id: :simple, path: "outer.inner.simple"}
       ]
     })
   end
@@ -81,7 +81,7 @@ RSpec.describe "Props::Template fragments" do
         inner: {foo:"bar"}
       },
       fragments: [
-        {type: "simple", partial: "simple", path: "outer.inner"}
+        {id: "simple", path: "outer.inner"}
       ],
       deferred: []
     })
@@ -103,7 +103,7 @@ RSpec.describe "Props::Template fragments" do
         inner: {}
       },
       fragments: [
-        {type: "simple", partial: "simple", path: "outer.inner"}
+        {id: "simple", path: "outer.inner"}
       ],
       deferred: [
         {url: "/?props_at=outer.inner", path: "outer.inner", type: "auto"}
@@ -135,8 +135,8 @@ RSpec.describe "Props::Template fragments" do
         {firstName: "foo"}
       ],
       fragments: [
-        {type: "user_list_item", partial: "customer", path: "data.0"},
-        {type: "user_list_item", partial: "customer", path: "data.1"}
+        {id: "user_list_item", path: "data.0"},
+        {id: "user_list_item", path: "data.1"}
       ]
     })
   end
@@ -172,8 +172,8 @@ RSpec.describe "Props::Template fragments" do
         }
       ],
       fragments: [
-        {type: "user", partial: "customer", path: "data.id=1"},
-        {type: "user", partial: "customer", path: "data.id=2"}
+        {id: "user", path: "data.id=1"},
+        {id: "user", path: "data.id=2"}
       ]
     })
   end
@@ -211,8 +211,8 @@ RSpec.describe "Props::Template fragments" do
         }
       ],
       fragments: [
-        {type: "user", partial: "person", path: "data.id=1"},
-        {type: "user", partial: "person", path: "data.id=2"}
+        {id: "user", path: "data.id=1"},
+        {id: "user", path: "data.id=2"}
       ]
     })
   end
@@ -247,8 +247,8 @@ RSpec.describe "Props::Template fragments" do
         }
       ],
       fragments: [
-        {type: "joe@red.com", partial: "person", path: "data.0"},
-        {type: "foo@red.com", partial: "person", path: "data.1"}
+        {id: "joe@red.com", path: "data.0"},
+        {id: "foo@red.com", path: "data.1"}
       ]
     })
   end

--- a/spec/extensions/partial_defer_extension_spec.rb
+++ b/spec/extensions/partial_defer_extension_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Props::Template fragments" do
         {url: "/some_url?props_at=outer.inner", path: "outer.inner", type: "auto"}
       ],
       fragments: [
-        {type: :simple, partial: "simple", path: "outer.inner"}
+        {id: :simple, path: "outer.inner"}
       ]
     })
   end
@@ -52,7 +52,7 @@ RSpec.describe "Props::Template fragments" do
         {url: "/some_url?props_at=outer.inner", path: "outer.inner", type: "auto"}
       ],
       fragments: [
-        {type: :simple, partial: "simple", path: "outer.inner"}
+        {id: :simple, path: "outer.inner"}
       ]
     })
   end


### PR DESCRIPTION
While this is a breaking change, Fragments is a specific feature for Superglue. This updates the naming so we use id instead of type.