### PR TITLE
Add support for fragment context

### DIFF
--- a/lib/props_template.rb
+++ b/lib/props_template.rb
@@ -30,11 +30,14 @@ module Props
       :disable_deferments!,
       :set_block_content!,
       :traveled_path!,
+      :fragment_context!,
       to: :builder!
 
     def initialize(context = nil, options = {})
       @builder = BaseWithExtensions.new(self, context, options)
       @context = context
+      @fragment_context = nil
+      @found_path = []
     end
 
     def set!(key, options = {}, &block)
@@ -48,7 +51,9 @@ module Props
         options.delete(:dig)
 
         @builder.set!(key, options, &block)
-        found_block, found_options = @builder.found!
+        found_block, found_path, found_options, fragment_context = @builder.found!
+        @found_path = found_path || []
+        @fragment_context = fragment_context
         @builder = prev_builder
 
         if found_block
@@ -57,6 +62,14 @@ module Props
       else
         @builder.set!(key, options, &block)
       end
+    end
+
+    def found_path!
+      @found_path.join(".")
+    end
+
+    def fragment_context!
+      @fragment_context
     end
 
     def builder!

--- a/lib/props_template/base_with_extensions.rb
+++ b/lib/props_template/base_with_extensions.rb
@@ -55,15 +55,16 @@ module Props
         options = @em.refine_options(options)
       end
 
-      super(key, options, &block)
+      super
     end
 
     def handle_set_block(key, options)
-      @traveled_path.push(key)
       n = 1
       if (suffix = options[:path_suffix])
         n += suffix.length
         @traveled_path.push(suffix)
+      else
+        @traveled_path.push(key)
       end
 
       super

--- a/lib/props_template/extensions/fragment.rb
+++ b/lib/props_template/extensions/fragment.rb
@@ -7,18 +7,28 @@ module Props
       @fragments = fragments
     end
 
-    def handle(options)
+    def self.fragment_name_from_options(options)
       return if !options[:partial]
-      _partial_name, partial_opts = options[:partial]
+
+      _, partial_opts = [*options[:partial]]
+      return unless partial_opts
+
       fragment = partial_opts[:fragment]
 
       if String === fragment || Symbol === fragment
-        key = fragment.to_s
-        path = @base.traveled_path.join(".")
-        @name =key 
+        fragment.to_s
+      end
+    end
 
+    def handle(options)
+      fragment_name = self.class.fragment_name_from_options(options)
+      path = @base.traveled_path
+        .map { |item| item.is_a?(Array) ? item[0] : item }
+        .join(".")
+
+      if fragment_name
         @fragments.push(
-          {id: key, path: path}
+          {id: fragment_name, path: path}
         )
       end
     end

--- a/spec/searcher_spec.rb
+++ b/spec/searcher_spec.rb
@@ -24,11 +24,12 @@ RSpec.describe "Searcher" do
       end
     end
 
-    found_block, found_options = json.found!
+    found_block, found_path, found_options = json.found!
     expect(found_block).to eql(target_proc)
+    expect(found_path).to eql ["outer", "inner", "hit"]
     expect(found_options).to eql({
       some_options: 1,
-      path_suffix: ["inner", "hit"]
+      path_suffix: ["outer", "inner", "hit"]
     })
   end
 
@@ -134,8 +135,9 @@ RSpec.describe "Searcher" do
       end
     end
 
-    found_block, found_options = json.found!
-    expect(found_options).to eql({some_options: 1, path_suffix: [1]})
+    found_block, found_path, found_options = json.found!
+    expect(found_options).to eql({some_options: 1, path_suffix: ["outer", 1]})
+    expect(found_path).to eql(["outer", 1])
     expect(found_block.call).to eql("world")
   end
 


### PR DESCRIPTION
This commit was missing from the 2.0 release and includes several related improvements:

1. Adds fragmentContext to allow digging using props_at to find a node, then considering what fragment it was found in, returns a `found_path` that can be used in a graft response's `path`. We'll need to replace the generated files in superglue_rails

2. Modifies `fragments!` to return paths that are relative to the data being presented. So instead of `data.a.deep.path.in.page` it returns. `data.a.deep.path.in.response` with the latter being much shorter.