### PR TITLE
Fix using partial! with digging

### DIFF
--- a/lib/props_template.rb
+++ b/lib/props_template.rb
@@ -64,6 +64,10 @@ module Props
       end
     end
 
+    def partial!(**options)
+      @context.render options
+    end
+
     def found_path!
       @found_path.join(".")
     end

--- a/lib/props_template/base.rb
+++ b/lib/props_template/base.rb
@@ -111,10 +111,6 @@ module Props
       nil
     end
 
-    def partial!(**options)
-      @context.render options
-    end
-
     # json.id item.id
     # json.value item.value
     #


### PR DESCRIPTION
When digging, we swap the builder instance, then when encountering `partial!` on an instance that does not have it implemented, it errors out. This moves the method to the top level top level props_template. So both instances have it.