### PR TITLE
Fix: Second props partial render on same view returns nil

### DIFF
--- a/lib/props_template/handler.rb
+++ b/lib/props_template/handler.rb
@@ -8,8 +8,8 @@ module Props
     def self.call(template, source = nil)
       source ||= template.source
       # this juggling is required to keep line numbers right in the error
-      %{ __finalize = !defined?(@__json); @__json ||= Props::Template.new(self); json = @__json; #{source};
-        json.result! if __finalize
+      %{ __finalize = @__json.nil?; @__json ||= Props::Template.new(self); json = @__json; #{source};
+        if __finalize; result = json.result!; @__json = nil; result; end
       }
     end
   end

--- a/spec/extensions/partial_render_spec.rb
+++ b/spec/extensions/partial_render_spec.rb
@@ -426,4 +426,28 @@ RSpec.describe "Props::Template" do
 
     expect(json).to eql_json([])
   end
+
+  it "renders a partial that itself renders two partials" do
+    json = render(<<~PROPS)
+      json.outer(partial: 'two_partials') do
+      end
+    PROPS
+
+    expect(json).to eql_json({
+      outer: {
+        simple: {foo: "bar"},
+        comment: {title: "some title", details: {body: "hello world"}}
+      }
+    })
+  end
+
+  it "renders two different partials sequentially on the same view context" do
+    view = build_view
+
+    result1 = view.render(partial: "simple", formats: [:json]).strip
+    result2 = view.render(partial: "comment", formats: [:json]).strip
+
+    expect(result1).to eql_json({foo: "bar"})
+    expect(result2).to eql_json({title: "some title", details: {body: "hello world"}})
+  end
 end

--- a/spec/fixtures/_two_partials.json.props
+++ b/spec/fixtures/_two_partials.json.props
@@ -1,0 +1,4 @@
+json.simple(partial: "simple") do
+end
+json.comment(partial: "comment") do
+end

--- a/spec/support/rails_helper.rb
+++ b/spec/support/rails_helper.rb
@@ -56,13 +56,17 @@ class << Rails
   end
 end
 
-def render(source, options = {})
+def build_view
   @controller.cache_store = Rails.cache
   view_path = File.join(File.dirname(__FILE__), "../fixtures")
   file_resolver = ActionView::FileSystemResolver.new(view_path)
   lookup_context = ActionView::LookupContext.new([file_resolver], {}, [""])
   lookup_context.formats = [:json]
-  view = FakeView.new(lookup_context, {}, @controller)
+  FakeView.new(lookup_context, {}, @controller)
+end
+
+def render(source, options = {})
+  view = build_view
   view.assign(options.fetch(:assigns, {}))
   template = ActionView::Template.new(source, "test", Props::Handler, virtual_path: "test", locals: [])
   template.render(view, {}).strip


### PR DESCRIPTION
This resolves #63. The bug only exists when calling props_template from another view twice.

The issue here was that `@__json` is an instance variable on the view, so it persisted after the first partial finalized — causing subsequent top-level renders to see it as already defined, skip result!, and return nil.

Normally, there is only 1 top level render, but calling it from another templating engine means there can be more than 1.

 The fix swaps `!defined?(@__json)` for `@__json.nil?`` and resets `@__json =
 nil` after `result!``, so each subsequent top-level render gets a fresh
 template.