### PR TITLE
Add basic generators

### DIFF
--- a/lib/generators/props/templates/index.json.props
+++ b/lib/generators/props/templates/index.json.props
@@ -1,0 +1,11 @@
+json.<%= js_plural_table_name %> do
+  json.array! @<%= plural_table_name %> do |<%= singular_table_name %>|
+    <%- attributes_list_with_timestamps.each do |attr| -%>
+    json.<%=attr.to_s.camelize(:lower)%> <%= singular_table_name %>.<%=attr%>
+    <%- end -%>
+    json.edit<%=js_singular_table_name(:upper)%>Path edit_<%=singular_table_name%>_path(<%=singular_table_name%>)
+    json.<%=js_singular_table_name%>Path <%=singular_table_name%>_path(<%=singular_table_name%>)
+  end
+end
+
+json.new<%= js_singular_table_name(:upper) %>Path new_<%= singular_table_name %>_path

--- a/lib/generators/props/templates/show.json.props
+++ b/lib/generators/props/templates/show.json.props
@@ -1,0 +1,6 @@
+<%- attributes_list_with_timestamps.each do |attr|-%>
+json.<%=attr.to_s.camelize(:lower)%> @<%= singular_table_name %>.<%=attr%>
+<%- end -%>
+
+json.<%= js_plural_table_name %>Path <%= plural_table_name %>_path
+json.edit<%= js_singular_table_name(:upper) %>Path edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)

--- a/lib/generators/props/views/USAGE
+++ b/lib/generators/props/views/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Generates PropsTemplate view files (.json.props) for a given resource.
+
+Example:
+    rails generate props:views Post title:string body:text
+
+    This will create:
+        app/views/posts/index.json.props
+        app/views/posts/show.json.props

--- a/lib/generators/props/views/views_generator.rb
+++ b/lib/generators/props/views/views_generator.rb
@@ -1,0 +1,64 @@
+require "rails/generators/named_base"
+require "rails/generators/resource_helpers"
+
+module Props
+  module Generators
+    class ViewsGenerator < Rails::Generators::NamedBase
+      include Rails::Generators::ResourceHelpers
+
+      source_root File.expand_path("../templates", __dir__)
+
+      argument :attributes, type: :array, default: [], banner: "field:type field:type"
+
+      def create_root_folder
+        path = File.join("app/views", controller_file_path)
+        empty_directory path unless File.directory?(path)
+      end
+
+      def copy_prop_files
+        available_views.each do |view|
+          @action_name = view
+          filename = filename_with_extensions(view)
+          template filename, File.join("app/views", controller_file_path, filename)
+        end
+      end
+
+      protected
+
+      def js_singular_table_name(casing = :lower)
+        singular_table_name.camelize(casing)
+      end
+
+      def js_plural_table_name(casing = :lower)
+        plural_table_name.camelize(casing)
+      end
+
+      def available_views
+        %w[index show]
+      end
+
+      attr_reader :action_name
+
+      def attributes_names
+        [:id] + super
+      end
+
+      def filename_with_extensions(name)
+        [name, :json, :props].join(".")
+      end
+
+
+      def attributes_list_with_timestamps
+        attributes_list(attributes_names + %w[created_at updated_at])
+      end
+
+      def attributes_list(attributes = attributes_names)
+        if self.attributes.any? { |attr| attr.name == "password" && attr.type == :digest }
+          attributes = attributes.reject { |name| %w[password password_confirmation].include? name }
+        end
+
+        attributes
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are basic generators that live in its own space. I decided not to modify the default scaffold generators as jbuilder: true is on by default.

```
Usage:
  bin/rails generate props:views NAME [field:type field:type] [options]

Options:
  [--skip-namespace]                                            # Skip namespace (affects only isolated engines)
                                                                # Default: false
  [--skip-collision-check]                                      # Skip collision check
                                                                # Default: false
  [--force-plural], [--no-force-plural], [--skip-force-plural]  # Do not singularize the model name, even if it appears plural
                                                                # Default: false
  [--model-name=MODEL_NAME]                                     # ModelName to be used

Runtime options:
  -f, [--force]                                      # Overwrite files that already exist
  -p, [--pretend], [--no-pretend], [--skip-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet], [--skip-quiet]        # Suppress status output
  -s, [--skip], [--no-skip], [--skip-skip]           # Skip files that already exist

Description:
    Generates PropsTemplate view files (.json.props) for a given resource.

Example:
    rails generate props:views Post title:string body:text

    This will create:
        app/views/posts/index.json.props
        app/views/posts/show.json.props
```